### PR TITLE
Update Riemann dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.7.0"]
                  [clj-time "0.13.0"]
-                 [riemann "0.2.13"]
+                 [riemann "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [cc.qbits/spandex "0.6.4"]]
   :plugins [[lein-rpm "0.0.5"


### PR DESCRIPTION
This fix a build issue:

```sh-session
romain@marvin ~/Projects/samplerr % lein uberjar
Tried to use insecure HTTP repository without TLS:
 fusesource: http://repo.fusesource.com/nexus/content/groups/public/
 com/googlecode/jsendnsca-core/1.3.1/jsendnsca-core-1.3.1.pom

This is almost certainly a mistake; for details see
https://github.com/technomancy/leiningen/blob/master/doc/FAQ.md
```