### PR TITLE
Decrease verbosity

### DIFF
--- a/src/riemann/plugin/samplerr.clj
+++ b/src/riemann/plugin/samplerr.clj
@@ -122,7 +122,7 @@
                       total (count (:items res))
                       succ (filter :_version (map :index (:items res)))
                       failed (filter :error (map :index (:items res)))]
-                  (info "elasticized" total " (total) " by_status " docs to " es_index "in " (:took res) "ms")
+                  (debug "elasticized" total " (total) " by_status " docs to " es_index "in " (:took res) "ms")
                   (debug "Failed: " failed))
                 (catch Exception e
                   (error "Unable to bulk index:" e)))))))))


### PR DESCRIPTION
The plugin logs a lot of information when everything is fine.  Decrease
the logging level of these informational messages.

The idea is to not have the following in riemann logs:
```
INFO [2020-06-09 21:30:02,148] defaultEventExecutorGroup-2-12 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  52 ms
INFO [2020-06-09 21:30:04,220] defaultEventExecutorGroup-2-8 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  90 ms
INFO [2020-06-09 21:30:05,282] defaultEventExecutorGroup-2-9 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  64 ms
INFO [2020-06-09 21:30:06,211] riemann task 1 - riemann.plugin.samplerr - elasticized 260  (total)  {201 260}  docs to  .samplerr-2020.06.10 in  42 ms
INFO [2020-06-09 21:30:16,298] riemann task 2 - riemann.plugin.samplerr - elasticized 596  (total)  {201 596}  docs to  .samplerr-2020.06.10 in  77 ms
INFO [2020-06-09 21:30:19,709] defaultEventExecutorGroup-2-11 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  122 ms
INFO [2020-06-09 21:30:22,278] defaultEventExecutorGroup-2-12 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  105 ms
INFO [2020-06-09 21:30:24,356] defaultEventExecutorGroup-2-8 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  57 ms
INFO [2020-06-09 21:30:25,435] defaultEventExecutorGroup-2-11 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  64 ms
INFO [2020-06-09 21:30:26,232] riemann task 2 - riemann.plugin.samplerr - elasticized 236  (total)  {201 236}  docs to  .samplerr-2020.06.10 in  58 ms
INFO [2020-06-09 21:30:36,257] riemann task 2 - riemann.plugin.samplerr - elasticized 596  (total)  {201 596}  docs to  .samplerr-2020.06.10 in  68 ms
INFO [2020-06-09 21:30:39,623] defaultEventExecutorGroup-2-2 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  87 ms
INFO [2020-06-09 21:30:42,221] defaultEventExecutorGroup-2-1 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  63 ms
INFO [2020-06-09 21:30:44,650] defaultEventExecutorGroup-2-11 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  87 ms
INFO [2020-06-09 21:30:45,525] defaultEventExecutorGroup-2-11 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  81 ms
INFO [2020-06-09 21:30:46,185] riemann task 2 - riemann.plugin.samplerr - elasticized 143  (total)  {201 143}  docs to  .samplerr-2020.06.10 in  16 ms
INFO [2020-06-09 21:30:56,265] riemann task 3 - riemann.plugin.samplerr - elasticized 550  (total)  {201 550}  docs to  .samplerr-2020.06.10 in  89 ms
INFO [2020-06-09 21:30:59,557] defaultEventExecutorGroup-2-7 - riemann.plugin.samplerr - elasticized 1000  (total)  {201 1000}  docs to  .samplerr-2020.06.10 in  42 ms
```