### PR TITLE
Tell which dependencies are provided

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,14 @@
   :url "http://github.com/samplerr/samplerr"
   :license {:name "EPL-1.0"
             :url "https://spdx.org/licenses/EPL-1.0.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cheshire "5.7.0"]
-                 [clj-time "0.13.0"]
-                 [riemann "0.3.1"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [cc.qbits/spandex "0.6.4"]]
+  :dependencies [[cc.qbits/spandex "0.6.4"]]
+  :profiles {:provided
+             {:dependencies
+              [[cheshire "5.7.0"]
+               [org.clojure/clojure "1.8.0"]
+               [riemann "0.3.1"]
+               [clj-time "0.13.0"]
+               [org.clojure/tools.logging "0.3.1"]]}}
   :plugins [[lein-rpm "0.0.5"
              :exclusions [org.apache.maven/maven-plugin-api
                           org.codehaus.plexus/plexus-container-default


### PR DESCRIPTION
When building an uberjar, we do not need all dependencies to be bundled,
only the few one that are not already part of Riemann itself.

With this PR applied, the uberjar size goes from 90 MB to 7 MB :tada: 