### PR TITLE
Update spandex version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/samplerr/samplerr"
   :license {:name "EPL-1.0"
             :url "https://spdx.org/licenses/EPL-1.0.html"}
-  :dependencies [[cc.qbits/spandex "0.6.4"]]
+  :dependencies [[cc.qbits/spandex "0.7.10"]]
   :profiles {:provided
              {:dependencies
               [[cheshire "5.7.0"]


### PR DESCRIPTION
The latest spandex has support for tweaking the SSL configuration we
will need to tweak when switching to OpenSearch or ElasticSearch with
encryption.
